### PR TITLE
Add FErki

### DIFF
--- a/authors/FERKI.json
+++ b/authors/FERKI.json
@@ -1,0 +1,17 @@
+{
+   "author" : {
+      "cpan" : "FERKI",
+      "github" : "ferki"
+   },
+   "ci" : {
+      "use_gh_actions" : 1,
+      "gh_workflow_names" : [ "build and test" ],
+      "use_cirrus" : 0,
+      "use_appveyor" : 0,
+      "use_travis" : 0,
+      "use_travis_com" : 0,
+      "use_coveralls" : 1,
+      "use_codecov" : 0,
+      "use_kritika" : 0
+   }
+}


### PR DESCRIPTION
This PR is an attempt to add myself to cpandashboard.com :)

One of my releases on CPAN (Rex), is not tracked under my own namespace on GitHub (`ferki`), but under a different organization account (`RexOps`). I am not sure how it will turn up on the dashboard now, and I wondered if there's anything I can/should do to specify that explicitly.

Please review and merge, or let me know how to improve it!
