### PR TITLE
import the add page

### DIFF
--- a/tt_lib/add.tt
+++ b/tt_lib/add.tt
@@ -7,8 +7,6 @@ CI services (but we plan to add support for more services in the future).</p>
 <p>Here are the steps to follow:</p>
 
 <ol>
-<li>Add a link to the code repos to the metadata of all of your CPAN modules.
-(Gabor has <a href="https://perlmaven.com/how-to-add-link-to-version-control-system-of-a-cpan-distributions"> a tutorial about that</a>.)</li>
 <li>Decide which of the supported CI services you want to use and configure
 them correctly. (More details on the various services below.)</li>
 <li>Take a fork of the <a href="https://github.com/davorg/dashboard">CPAN Dashboard</a> repo.</li>
@@ -183,3 +181,16 @@ script:
     </div>
   </div>
 </div>
+
+<h2>Fixing issues</h2>
+
+A number of issue that could be discovered by the CPAN Dashboard and how to fix them.
+
+<ul>
+<li>Add a link to the code repos to the metadata of all of your CPAN modules.
+(Gabor has <a href="https://perlmaven.com/how-to-add-link-to-version-control-system-of-a-cpan-distributions"> a tutorial about that</a>.)</li>
+<li>Configure GitHub Actions</li>
+<li>Configure Coveralls</li>
+<li>...</li>
+</ul>
+


### PR DESCRIPTION
Adding the github link to each repo is not a prerequisite of setting up the dashboard. It is one of the things how the author an improve things, both for the general public and for the dashboard.